### PR TITLE
made it so instead of having to specify cinematic camera group for ci…

### DIFF
--- a/actors/characters/enemies/bosses/gluttony/gluttony.tscn
+++ b/actors/characters/enemies/bosses/gluttony/gluttony.tscn
@@ -634,25 +634,13 @@ tracks/3/keys = {
 "method": &"play_fork"
 }]
 }
-tracks/4/type = "value"
+tracks/4/type = "method"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("IntroCinematic/Shot1:current")
-tracks/4/interp = 0
+tracks/4/path = NodePath("Shake")
+tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
-"times": PackedFloat32Array(0, 3.58333, 7.08333),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [false, true, false]
-}
-tracks/5/type = "method"
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/path = NodePath("Shake")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/keys = {
 "times": PackedFloat32Array(7.125),
 "transitions": PackedFloat32Array(1),
 "values": [{
@@ -660,13 +648,13 @@ tracks/5/keys = {
 "method": &"continious_tremor"
 }]
 }
-tracks/6/type = "method"
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/path = NodePath("Audio/Music")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/keys = {
+tracks/5/type = "method"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("Audio/Music")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
 "times": PackedFloat32Array(12.125),
 "transitions": PackedFloat32Array(1),
 "values": [{
@@ -674,23 +662,23 @@ tracks/6/keys = {
 "method": &"play"
 }]
 }
-tracks/7/type = "animation"
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/path = NodePath("Mesh/gluttony/AnimationPlayer")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/keys = {
+tracks/6/type = "animation"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("Mesh/gluttony/AnimationPlayer")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
 "clips": PackedStringArray("GOBBLE"),
 "times": PackedFloat32Array(0.583333)
 }
-tracks/8/type = "audio"
-tracks/8/imported = false
-tracks/8/enabled = true
-tracks/8/path = NodePath("Audio/AudioStreamPlayer")
-tracks/8/interp = 1
-tracks/8/loop_wrap = true
-tracks/8/keys = {
+tracks/7/type = "audio"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("Audio/AudioStreamPlayer")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
 "clips": [{
 "end_offset": 0.0,
 "start_offset": 6.49853,
@@ -698,30 +686,46 @@ tracks/8/keys = {
 }],
 "times": PackedFloat32Array(7)
 }
-tracks/8/use_blend = true
-tracks/9/type = "value"
-tracks/9/imported = false
-tracks/9/enabled = true
-tracks/9/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/LookAtModifier3D:influence")
-tracks/9/interp = 1
-tracks/9/loop_wrap = true
-tracks/9/keys = {
+tracks/7/use_blend = true
+tracks/8/type = "value"
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/LookAtModifier3D:influence")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/keys = {
 "times": PackedFloat32Array(0, 0.541667, 0.583333, 9.29166, 15),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1),
 "update": 0,
 "values": [1.0, 1.0, 0.0, 0.0, 1.0]
 }
-tracks/10/type = "value"
+tracks/9/type = "method"
+tracks/9/imported = false
+tracks/9/enabled = true
+tracks/9/path = NodePath("IntroCinematic/Shot1")
+tracks/9/interp = 1
+tracks/9/loop_wrap = true
+tracks/9/keys = {
+"times": PackedFloat32Array(0.5833),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"make_current"
+}]
+}
+tracks/10/type = "method"
 tracks/10/imported = false
 tracks/10/enabled = true
-tracks/10/path = NodePath("IntroCinematic/Shot2:current")
-tracks/10/interp = 0
+tracks/10/path = NodePath("IntroCinematic/Shot2")
+tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/keys = {
-"times": PackedFloat32Array(0, 0.583333, 3.58333, 7.08333, 16.5),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1),
-"update": 0,
-"values": [false, true, false, true, false]
+"times": PackedFloat32Array(3.5833),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"make_current"
+}]
 }
 tracks/11/type = "value"
 tracks/11/imported = false
@@ -969,130 +973,106 @@ tracks/14/keys = {
 tracks/15/type = "value"
 tracks/15/imported = false
 tracks/15/enabled = true
-tracks/15/path = NodePath("IntroCinematic/Shot2:current")
+tracks/15/path = NodePath("IntroCinematic/ColorRect:color")
 tracks/15/interp = 1
 tracks/15/loop_wrap = true
 tracks/15/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
+"update": 0,
+"values": [Color(0, 0, 0, 0)]
 }
 tracks/16/type = "value"
 tracks/16/imported = false
 tracks/16/enabled = true
-tracks/16/path = NodePath("IntroCinematic/ColorRect:color")
+tracks/16/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/Retopo:material_override:shader_parameter/dissolve_amount")
 tracks/16/interp = 1
 tracks/16/loop_wrap = true
 tracks/16/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Color(0, 0, 0, 0)]
+"values": [0.0]
 }
 tracks/17/type = "value"
 tracks/17/imported = false
 tracks/17/enabled = true
-tracks/17/path = NodePath("IntroCinematic/Shot1:current")
+tracks/17/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/LeftLeg/AttackArea/CollisionShape3D:disabled")
 tracks/17/interp = 1
 tracks/17/loop_wrap = true
 tracks/17/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [false]
+"values": [true]
 }
 tracks/18/type = "value"
 tracks/18/imported = false
 tracks/18/enabled = true
-tracks/18/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/Retopo:material_override:shader_parameter/dissolve_amount")
+tracks/18/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/RightLeg/AttackArea/CollisionShape3D:disabled")
 tracks/18/interp = 1
 tracks/18/loop_wrap = true
 tracks/18/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [0.0]
+"update": 1,
+"values": [true]
 }
 tracks/19/type = "value"
 tracks/19/imported = false
 tracks/19/enabled = true
-tracks/19/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/LeftLeg/AttackArea/CollisionShape3D:disabled")
+tracks/19/path = NodePath("Audio/Music:volume_db")
 tracks/19/interp = 1
 tracks/19/loop_wrap = true
 tracks/19/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
+"update": 0,
+"values": [0.0]
 }
 tracks/20/type = "value"
 tracks/20/imported = false
 tracks/20/enabled = true
-tracks/20/path = NodePath("Mesh/gluttony/Armature/Skeleton3D/RightLeg/AttackArea/CollisionShape3D:disabled")
+tracks/20/path = NodePath("Target:position")
 tracks/20/interp = 1
 tracks/20/loop_wrap = true
 tracks/20/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
+"update": 0,
+"values": [Vector3(0, 0, 2.45932)]
 }
 tracks/21/type = "value"
 tracks/21/imported = false
 tracks/21/enabled = true
-tracks/21/path = NodePath("Audio/Music:volume_db")
+tracks/21/path = NodePath("Target:MATCH_POSITION")
 tracks/21/interp = 1
 tracks/21/loop_wrap = true
 tracks/21/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [0.0]
+"update": 1,
+"values": [true]
 }
 tracks/22/type = "value"
 tracks/22/imported = false
 tracks/22/enabled = true
-tracks/22/path = NodePath("Target:position")
+tracks/22/path = NodePath("Mesh/Jump/CollisionShape3D:shape:radius")
 tracks/22/interp = 1
 tracks/22/loop_wrap = true
 tracks/22/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector3(0, 0, 2.45932)]
+"values": [40.0]
 }
 tracks/23/type = "value"
 tracks/23/imported = false
 tracks/23/enabled = true
-tracks/23/path = NodePath("Target:MATCH_POSITION")
+tracks/23/path = NodePath("Target:USE_GRAVITY")
 tracks/23/interp = 1
 tracks/23/loop_wrap = true
 tracks/23/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-tracks/24/type = "value"
-tracks/24/imported = false
-tracks/24/enabled = true
-tracks/24/path = NodePath("Mesh/Jump/CollisionShape3D:shape:radius")
-tracks/24/interp = 1
-tracks/24/loop_wrap = true
-tracks/24/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [40.0]
-}
-tracks/25/type = "value"
-tracks/25/imported = false
-tracks/25/enabled = true
-tracks/25/path = NodePath("Target:USE_GRAVITY")
-tracks/25/interp = 1
-tracks/25/loop_wrap = true
-tracks/25/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
@@ -2003,7 +1983,7 @@ ANIMATION_NAMES = Array[String](["GLUTTONY_INTRO"])
 transform = Transform3D(0.876727, -0.146636, -0.458092, 0, 0.952396, -0.304864, 0.480989, 0.267282, 0.834991, -4.37286, 0.471814, 3.22674)
 fov = 79.0
 
-[node name="Shot2" type="Camera3D" parent="IntroCinematic" groups=["cinematic_camera"]]
+[node name="Shot2" type="Camera3D" parent="IntroCinematic"]
 transform = Transform3D(0.958819, -0.0638897, 0.276737, 0, 0.97437, 0.224951, -0.284016, -0.215688, 0.934245, 11.6795, 14.4465, 50.4496)
 fov = 10.5
 

--- a/actors/characters/enemies/bosses/lust/lust.tscn
+++ b/actors/characters/enemies/bosses/lust/lust.tscn
@@ -587,65 +587,67 @@ tracks/8/path = NodePath("IntroCinematic/Camera3D")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = PackedFloat32Array(0.375, 1, -0.14223, 6.00946, 6.49053)
-tracks/9/type = "value"
+tracks/9/type = "method"
 tracks/9/imported = false
 tracks/9/enabled = true
-tracks/9/path = NodePath("IntroCinematic/Camera3D:position")
-tracks/9/interp = 2
+tracks/9/path = NodePath("IntroCinematic/Camera3D")
+tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/keys = {
+"times": PackedFloat32Array(0.4583),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"make_current"
+}]
+}
+tracks/10/type = "value"
+tracks/10/imported = false
+tracks/10/enabled = true
+tracks/10/path = NodePath("IntroCinematic/Camera3D:position")
+tracks/10/interp = 2
+tracks/10/loop_wrap = true
+tracks/10/keys = {
 "times": PackedFloat32Array(0.875, 2.08333, 3.54167),
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
 "values": [Vector3(-0.062, 10.294, 9.691), Vector3(-0.062, 7.454, 7.596), Vector3(-0.102, 5.099, 2.902)]
 }
-tracks/10/type = "value"
-tracks/10/imported = false
-tracks/10/enabled = true
-tracks/10/path = NodePath("IntroCinematic/Camera3D:rotation")
-tracks/10/interp = 2
-tracks/10/loop_wrap = true
-tracks/10/keys = {
+tracks/11/type = "value"
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/path = NodePath("IntroCinematic/Camera3D:rotation")
+tracks/11/interp = 2
+tracks/11/loop_wrap = true
+tracks/11/keys = {
 "times": PackedFloat32Array(0.905, 3.54167),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Vector3(-0.513127, 0, 0), Vector3(0.0662448, -0.0393017, 0)]
 }
-tracks/11/type = "value"
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/path = NodePath("IntroCinematic/Camera3D:fov")
-tracks/11/interp = 2
-tracks/11/loop_wrap = true
-tracks/11/keys = {
+tracks/12/type = "value"
+tracks/12/imported = false
+tracks/12/enabled = true
+tracks/12/path = NodePath("IntroCinematic/Camera3D:fov")
+tracks/12/interp = 2
+tracks/12/loop_wrap = true
+tracks/12/keys = {
 "times": PackedFloat32Array(0.75, 3.95833, 4.52, 4.75),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [46.3, 34.4, 34.4, 45.0]
 }
-tracks/12/type = "value"
-tracks/12/imported = false
-tracks/12/enabled = true
-tracks/12/path = NodePath("Target:TRACKING_MULTIPLIER")
-tracks/12/interp = 1
-tracks/12/loop_wrap = true
-tracks/12/keys = {
+tracks/13/type = "value"
+tracks/13/imported = false
+tracks/13/enabled = true
+tracks/13/path = NodePath("Target:TRACKING_MULTIPLIER")
+tracks/13/interp = 1
+tracks/13/loop_wrap = true
+tracks/13/keys = {
 "times": PackedFloat32Array(5.625, 6.125),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [0.0, 1.0]
-}
-tracks/13/type = "value"
-tracks/13/imported = false
-tracks/13/enabled = true
-tracks/13/path = NodePath("IntroCinematic/Camera3D:current")
-tracks/13/interp = 0
-tracks/13/loop_wrap = true
-tracks/13/keys = {
-"times": PackedFloat32Array(0, 0.458333, 6.25),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [false, true, false]
 }
 tracks/14/type = "value"
 tracks/14/imported = false
@@ -858,65 +860,65 @@ tracks/10/keys = {
 "update": 1,
 "values": [true]
 }
-tracks/11/type = "value"
+tracks/11/type = "position_3d"
 tracks/11/imported = false
 tracks/11/enabled = true
-tracks/11/path = NodePath("IntroCinematic/Camera3D:current")
+tracks/11/path = NodePath("IntroCinematic/Camera3D")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
-tracks/11/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/12/type = "position_3d"
+tracks/11/keys = PackedFloat32Array(0, 1, -0.14223, 6.00946, 6.49053)
+tracks/12/type = "value"
 tracks/12/imported = false
 tracks/12/enabled = true
-tracks/12/path = NodePath("IntroCinematic/Camera3D")
+tracks/12/path = NodePath("IntroCinematic/Camera3D:position")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
-tracks/12/keys = PackedFloat32Array(0, 1, -0.14223, 6.00946, 6.49053)
+tracks/12/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(1.073, 5.099, 6.491)]
+}
 tracks/13/type = "value"
 tracks/13/imported = false
 tracks/13/enabled = true
-tracks/13/path = NodePath("IntroCinematic/Camera3D:position")
+tracks/13/path = NodePath("IntroCinematic/Camera3D:rotation")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector3(1.073, 5.099, 6.491)]
+"values": [Vector3(-0.0685565, 0, 0)]
 }
 tracks/14/type = "value"
 tracks/14/imported = false
 tracks/14/enabled = true
-tracks/14/path = NodePath("IntroCinematic/Camera3D:rotation")
+tracks/14/path = NodePath("IntroCinematic/Camera3D:fov")
 tracks/14/interp = 1
 tracks/14/loop_wrap = true
 tracks/14/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector3(-0.0685565, 0, 0)]
+"values": [35.5821]
 }
 tracks/15/type = "value"
 tracks/15/imported = false
 tracks/15/enabled = true
-tracks/15/path = NodePath("IntroCinematic/Camera3D:fov")
+tracks/15/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/FrontTail/AttackArea/CollisionShape3D:disabled")
 tracks/15/interp = 1
 tracks/15/loop_wrap = true
 tracks/15/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [35.5821]
+"update": 1,
+"values": [true]
 }
 tracks/16/type = "value"
 tracks/16/imported = false
 tracks/16/enabled = true
-tracks/16/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/FrontTail/AttackArea/CollisionShape3D:disabled")
+tracks/16/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/MiddleTail/AttackArea/CollisionShape3D:disabled")
 tracks/16/interp = 1
 tracks/16/loop_wrap = true
 tracks/16/keys = {
@@ -928,92 +930,80 @@ tracks/16/keys = {
 tracks/17/type = "value"
 tracks/17/imported = false
 tracks/17/enabled = true
-tracks/17/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/MiddleTail/AttackArea/CollisionShape3D:disabled")
+tracks/17/path = NodePath("Dialogue/CollisionShape3D:disabled")
 tracks/17/interp = 1
 tracks/17/loop_wrap = true
 tracks/17/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [true]
+"values": [false]
 }
 tracks/18/type = "value"
 tracks/18/imported = false
 tracks/18/enabled = true
-tracks/18/path = NodePath("Dialogue/CollisionShape3D:disabled")
+tracks/18/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/lust:surface_material_override/0:shader_parameter/albedo_texture")
 tracks/18/interp = 1
 tracks/18/loop_wrap = true
 tracks/18/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [false]
+"values": [ExtResource("24_fr36l")]
 }
 tracks/19/type = "value"
 tracks/19/imported = false
 tracks/19/enabled = true
-tracks/19/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/lust:surface_material_override/0:shader_parameter/albedo_texture")
+tracks/19/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/lust:blend_shapes/Calm")
 tracks/19/interp = 1
 tracks/19/loop_wrap = true
 tracks/19/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [ExtResource("24_fr36l")]
+"update": 0,
+"values": [1.0]
 }
 tracks/20/type = "value"
 tracks/20/imported = false
 tracks/20/enabled = true
-tracks/20/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/lust:blend_shapes/Calm")
+tracks/20/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/lust:surface_material_override/0:shader_parameter/dissolve_amount")
 tracks/20/interp = 1
 tracks/20/loop_wrap = true
 tracks/20/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [1.0]
+"values": [0.0]
 }
-tracks/21/type = "value"
+tracks/21/type = "animation"
 tracks/21/imported = false
 tracks/21/enabled = true
-tracks/21/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/lust:surface_material_override/0:shader_parameter/dissolve_amount")
+tracks/21/path = NodePath("Mesh/lus_shape_key/AnimationPlayer")
 tracks/21/interp = 1
 tracks/21/loop_wrap = true
 tracks/21/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [0.0]
+"clips": PackedStringArray("Idle"),
+"times": PackedFloat32Array(0)
 }
-tracks/22/type = "animation"
+tracks/22/type = "value"
 tracks/22/imported = false
 tracks/22/enabled = true
-tracks/22/path = NodePath("Mesh/lus_shape_key/AnimationPlayer")
+tracks/22/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/LookAtModifier3D:influence")
 tracks/22/interp = 1
 tracks/22/loop_wrap = true
 tracks/22/keys = {
-"clips": PackedStringArray("Idle"),
-"times": PackedFloat32Array(0)
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [1.0]
 }
 tracks/23/type = "value"
 tracks/23/imported = false
 tracks/23/enabled = true
-tracks/23/path = NodePath("Mesh/lus_shape_key/Armature/Skeleton3D/LookAtModifier3D:influence")
+tracks/23/path = NodePath("IntroCinematic/ColorRect:color")
 tracks/23/interp = 1
 tracks/23/loop_wrap = true
 tracks/23/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [1.0]
-}
-tracks/24/type = "value"
-tracks/24/imported = false
-tracks/24/enabled = true
-tracks/24/path = NodePath("IntroCinematic/ColorRect:color")
-tracks/24/interp = 1
-tracks/24/loop_wrap = true
-tracks/24/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
@@ -1068,53 +1058,55 @@ tracks/3/path = NodePath("IntroCinematic/Camera3D")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = PackedFloat32Array(0.375, 1, -0.14223, 6.00946, 6.49053)
-tracks/4/type = "value"
+tracks/4/type = "method"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("IntroCinematic/Camera3D:position")
-tracks/4/interp = 2
+tracks/4/path = NodePath("IntroCinematic/Camera3D")
+tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
+"times": PackedFloat32Array(0.4583),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"make_current"
+}]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("IntroCinematic/Camera3D:position")
+tracks/5/interp = 2
+tracks/5/loop_wrap = true
+tracks/5/keys = {
 "times": PackedFloat32Array(0.875, 2.08333, 3.54167),
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
 "values": [Vector3(-0.062, 10.294, 9.691), Vector3(-0.062, 7.454, 7.596), Vector3(-0.102, 5.099, 2.902)]
 }
-tracks/5/type = "value"
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/path = NodePath("IntroCinematic/Camera3D:rotation")
-tracks/5/interp = 2
-tracks/5/loop_wrap = true
-tracks/5/keys = {
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("IntroCinematic/Camera3D:rotation")
+tracks/6/interp = 2
+tracks/6/loop_wrap = true
+tracks/6/keys = {
 "times": PackedFloat32Array(0.905, 3.54167),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Vector3(-0.513127, 0, 0), Vector3(0.0662448, -0.0393017, 0)]
 }
-tracks/6/type = "value"
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/path = NodePath("IntroCinematic/Camera3D:fov")
-tracks/6/interp = 2
-tracks/6/loop_wrap = true
-tracks/6/keys = {
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("IntroCinematic/Camera3D:fov")
+tracks/7/interp = 2
+tracks/7/loop_wrap = true
+tracks/7/keys = {
 "times": PackedFloat32Array(0.75, 3.95833, 4.52, 5.01167),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [46.3, 34.4, 34.4, 80.0]
-}
-tracks/7/type = "value"
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/path = NodePath("IntroCinematic/Camera3D:current")
-tracks/7/interp = 0
-tracks/7/loop_wrap = true
-tracks/7/keys = {
-"times": PackedFloat32Array(0, 0.458333, 4.54167),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [false, true, false]
 }
 tracks/8/type = "value"
 tracks/8/imported = false
@@ -1568,7 +1560,7 @@ script = ExtResource("23_ri2mk")
 ANIMATION_PLAYER_GROUPS = Array[String](["player_anim"])
 ANIMATION_NAMES = Array[String](["LUST_INTRO"])
 
-[node name="Camera3D" type="Camera3D" parent="IntroCinematic" groups=["cinematic_camera"]]
+[node name="Camera3D" type="Camera3D" parent="IntroCinematic"]
 transform = Transform3D(1, 0, 0, 0, 0.997651, 0.0685028, 0, -0.0685028, 0.997651, 1.073, 5.099, 6.491)
 fov = 35.5821
 
@@ -1705,7 +1697,7 @@ blend_shapes/Calm = 1.0
 surface_material_override/0 = ExtResource("30_gn5mi")
 
 [node name="FrontTail" type="BoneAttachment3D" parent="Mesh/lus_shape_key/Armature/Skeleton3D" index="1"]
-transform = Transform3D(0.679061, 0.734082, 6.4075e-07, -4.47035e-07, -4.32134e-07, 1, 0.734082, -0.67906, -1.93715e-07, 0.387463, 0.543822, -1.51276)
+transform = Transform3D(0.679059, 0.734084, 0, 6.70552e-08, -2.98023e-08, 1, 0.734083, -0.679059, -2.83122e-07, 0.387464, 0.543822, -1.51276)
 bone_name = "tail.006"
 bone_idx = 70
 
@@ -1721,7 +1713,7 @@ disabled = true
 debug_color = Color(0.73, 0.73, 0.73, 0)
 
 [node name="MiddleTail" type="BoneAttachment3D" parent="Mesh/lus_shape_key/Armature/Skeleton3D" index="2"]
-transform = Transform3D(0.479655, -0.876594, -0.0389041, -1.93249e-07, -0.0443375, 0.999017, -0.877457, -0.479183, -0.0212671, 0.166105, 0.51728, -5.01815)
+transform = Transform3D(0.479658, -0.876593, -0.0389047, 5.07571e-08, -0.044338, 0.999016, -0.877455, -0.479186, -0.0212673, 0.166113, 0.51728, -5.01815)
 bone_name = "tail.009"
 bone_idx = 73
 
@@ -1737,7 +1729,7 @@ disabled = true
 debug_color = Color(0.73, 0.73, 0.73, 0)
 
 [node name="BackTail" type="BoneAttachment3D" parent="Mesh/lus_shape_key/Armature/Skeleton3D" index="3"]
-transform = Transform3D(0.999814, 0.0192687, 0.000589481, -4.63799e-07, -0.0305533, 0.999533, 0.0192776, -0.999347, -0.0305478, -2.09095, 0.378556, -6.99833)
+transform = Transform3D(0.999814, 0.0192723, 0.000589048, 8.56817e-08, -0.0305533, 0.999533, 0.019281, -0.999347, -0.0305479, -2.09093, 0.378554, -6.99834)
 bone_name = "tail.011"
 bone_idx = 75
 
@@ -1753,7 +1745,7 @@ disabled = true
 debug_color = Color(0.73, 0.73, 0.73, 0)
 
 [node name="LeftHand" type="BoneAttachment3D" parent="Mesh/lus_shape_key/Armature/Skeleton3D" index="4"]
-transform = Transform3D(-0.927089, 0.374499, -0.0160231, -0.374751, -0.925079, 0.061571, 0.00823557, 0.0630862, 0.997974, 0.85322, 3.89527, -0.380514)
+transform = Transform3D(-0.927089, 0.374499, -0.0160225, -0.374752, -0.925079, 0.0615698, 0.00823572, 0.063085, 0.997974, 0.853219, 3.89528, -0.380515)
 bone_name = "hand_l"
 bone_idx = 6
 
@@ -1769,7 +1761,7 @@ disabled = true
 debug_color = Color(0.95, 0.038, 0.1748, 0.180392)
 
 [node name="RightHand" type="BoneAttachment3D" parent="Mesh/lus_shape_key/Armature/Skeleton3D" index="5"]
-transform = Transform3D(-0.908106, -0.418698, 0.00592329, 0.418253, -0.906277, 0.06105, -0.0201931, 0.0579171, 0.998117, -0.956143, 3.93816, -0.392303)
+transform = Transform3D(-0.908106, -0.4187, 0.00592293, 0.418255, -0.906276, 0.0610496, -0.0201935, 0.0579168, 0.998117, -0.956145, 3.93817, -0.392304)
 bone_name = "hand_r"
 bone_idx = 51
 
@@ -1929,7 +1921,7 @@ settings/0/enable_all_child_collisions = true
 settings/0/exclude_collision_count = 0
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="Mesh/lus_shape_key/Armature/Skeleton3D" index="12"]
-transform = Transform3D(0.999701, 0.0208961, -0.012685, -0.0236265, 0.959108, -0.282055, 0.00627245, 0.28227, 0.959314, -0.0288818, 5.0388, 0.230216)
+transform = Transform3D(0.999701, 0.0208961, -0.012685, -0.0236265, 0.959107, -0.282056, 0.00627243, 0.282271, 0.959314, -0.0288818, 5.0388, 0.230217)
 bone_name = "neck"
 bone_idx = 20
 

--- a/actors/characters/player/reaper.tscn
+++ b/actors/characters/player/reaper.tscn
@@ -2505,40 +2505,39 @@ omni_range = 17.0156
 [node name="reaper" parent="Mesh" instance=ExtResource("3_k4avc")]
 
 [node name="Skeleton3D" parent="Mesh/reaper/Reaper" index="0"]
-bones/0/position = Vector3(0.00256202, 0.0489489, 0.0948707)
-bones/0/rotation = Quaternion(-0.612935, -0.00560519, 0.00434832, 0.790102)
-bones/1/position = Vector3(0.0123235, 0.197681, 0.868509)
-bones/1/rotation = Quaternion(0.596195, 0.00308748, -0.00436327, 0.802822)
-bones/2/rotation = Quaternion(0.0349499, 1.21201e-07, 2.28839e-09, 0.999389)
-bones/3/position = Vector3(-0.134822, 0.0525756, -0.0037891)
-bones/3/rotation = Quaternion(-0.0860238, -0.862328, 0.270469, 0.41933)
-bones/4/rotation = Quaternion(-0.190912, 0.287599, 0.144214, 0.927384)
-bones/5/rotation = Quaternion(-0.122516, -0.136265, 0.110098, 0.976883)
+bones/0/rotation = Quaternion(-0.707089, -0.00501628, 0.00501628, 0.707089)
+bones/1/position = Vector3(0.011758, 0.194371, 0.854838)
+bones/1/rotation = Quaternion(0.666525, 0.00528841, -0.00472851, 0.745449)
+bones/2/rotation = Quaternion(1.86264e-09, 1.21443e-07, -1.86265e-09, 1)
+bones/3/position = Vector3(-0.134822, 0.052576, -0.00378909)
+bones/3/rotation = Quaternion(-0.0791568, -0.242246, 0.807361, 0.532184)
+bones/4/rotation = Quaternion(-0.708254, 0.120146, -0.332469, 0.61107)
+bones/5/rotation = Quaternion(-0.106005, -0.0843838, 0.0754514, 0.987902)
 bones/6/rotation = Quaternion(-0.645197, -0.369968, -0.17571, 0.644957)
-bones/7/position = Vector3(0.0950238, 0.298836, -0.0378842)
+bones/7/position = Vector3(0.0950237, 0.298836, -0.0378842)
 bones/7/rotation = Quaternion(-0.0880253, 0.319577, -0.443777, 0.832577)
-bones/8/position = Vector3(0.0402784, 0.373751, 0.0192499)
+bones/8/position = Vector3(0.0402783, 0.37375, 0.0192499)
 bones/8/rotation = Quaternion(-0.590165, -0.329685, -0.328786, 0.659479)
-bones/9/rotation = Quaternion(0.229657, 0.0112931, 0.0685656, 0.970788)
-bones/10/position = Vector3(0.0739061, 0.0863636, 1.07372e-08)
-bones/10/rotation = Quaternion(0.00696048, 0.524812, -0.640908, 0.560144)
-bones/11/rotation = Quaternion(-0.418936, -0.430743, 0.0655356, 0.796654)
-bones/12/rotation = Quaternion(0.249308, -0.230606, 0.168459, 0.925358)
+bones/9/rotation = Quaternion(0.0637889, 0.000340956, -0.00206732, 0.997961)
+bones/10/position = Vector3(0.0739062, 0.0863639, 2.37346e-08)
+bones/10/rotation = Quaternion(-0.115372, -0.050699, -0.859753, 0.494917)
+bones/11/rotation = Quaternion(-0.458322, -0.406508, 0.068734, 0.787381)
+bones/12/rotation = Quaternion(-0.0341439, 0.039829, 0.140836, 0.988642)
 bones/13/rotation = Quaternion(-0.680775, 0.0647394, -0.215597, 0.697046)
-bones/14/position = Vector3(-0.00843, 0.293147, 0.000175848)
-bones/14/rotation = Quaternion(-0.498519, -8.94824e-05, 0.259607, 0.827093)
-bones/15/position = Vector3(-0.104507, 0.226166, -0.0265585)
-bones/15/rotation = Quaternion(-0.270376, 0.39151, -0.216351, 0.852531)
-bones/16/position = Vector3(-0.0949471, -0.102443, -0.00616009)
-bones/16/rotation = Quaternion(0.0375063, 0.069053, 0.996308, 0.034574)
-bones/17/rotation = Quaternion(0.221879, 0.0471956, 0.0239582, 0.973637)
-bones/18/rotation = Quaternion(-0.527103, 0.000813269, 0.00228507, 0.849798)
-bones/19/position = Vector3(0.0744179, -0.181045, 0.00460594)
-bones/19/rotation = Quaternion(-0.0131813, 0.0785921, 0.996804, -0.00566599)
-bones/20/rotation = Quaternion(0.232245, -0.0145044, 0.000666632, 0.972549)
-bones/21/rotation = Quaternion(-0.772792, 0.00515115, 0.00134369, 0.634637)
-bones/22/position = Vector3(0.0164243, 0.665742, 1.65289)
-bones/22/rotation = Quaternion(0.554553, 0.116061, 0.621623, 0.540911)
+bones/14/position = Vector3(0.0097023, 0.14449, -0.0938516)
+bones/14/rotation = Quaternion(-0.498519, -8.94973e-05, 0.259607, 0.827093)
+bones/15/position = Vector3(-0.104507, 0.226166, -0.0265586)
+bones/15/rotation = Quaternion(-0.396715, 0.383495, -0.189197, 0.812252)
+bones/16/position = Vector3(-0.0745593, -0.0469273, -3.05887e-08)
+bones/16/rotation = Quaternion(0.0101559, -0.186483, 0.982371, 0.0083134)
+bones/17/rotation = Quaternion(0.0230632, 0.000157504, 0.00323349, 0.999729)
+bones/18/rotation = Quaternion(-0.61167, 0.00253319, 0.000890185, 0.791109)
+bones/19/position = Vector3(0.0745593, -0.0469273, -3.16411e-08)
+bones/19/rotation = Quaternion(-0.00628432, 0.120802, 0.992616, -0.00893624)
+bones/20/rotation = Quaternion(0.0230632, -0.00015751, -0.0032335, 0.999729)
+bones/21/rotation = Quaternion(-0.792553, 0.0020302, -0.00182285, 0.609797)
+bones/22/position = Vector3(0.113311, 0.465548, 1.03604)
+bones/22/rotation = Quaternion(0.602369, -0.40178, 0.123678, 0.678548)
 
 [node name="body" parent="Mesh/reaper/Reaper/Skeleton3D" index="0"]
 material_override = ExtResource("35_m1s71")
@@ -2547,7 +2546,7 @@ material_override = ExtResource("35_m1s71")
 material_override = ExtResource("36_4anjp")
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="Mesh/reaper/Reaper/Skeleton3D" index="3"]
-transform = Transform3D(0.192208, -0.554266, 0.809843, 0.748053, 0.616891, 0.244665, -0.635194, 0.558779, 0.533192, -0.00446622, 1.81551, -0.139075)
+transform = Transform3D(0.636638, -0.662005, -0.395527, 0.703357, 0.70877, -0.0541693, 0.316198, -0.24371, 0.916855, 0.0986003, 1.03755, -0.215548)
 bone_name = "staff_2"
 bone_idx = 22
 
@@ -2578,7 +2577,7 @@ PLAYER = NodePath("../../../../../../..")
 ATTACK_AREA = NodePath("..")
 
 [node name="left_foot" type="BoneAttachment3D" parent="Mesh/reaper/Reaper/Skeleton3D" index="4"]
-transform = Transform3D(-0.999908, 0.0135875, -0.000293263, -0.011904, -0.886026, -0.463482, -0.00655741, -0.463436, 0.886106, -0.116333, 0.116391, 0.42105)
+transform = Transform3D(-0.99982, -0.0154742, -0.0110165, 0.0115822, -0.0369606, -0.999249, 0.0150555, -0.999197, 0.0371333, -0.0882446, 0.0295319, -0.130525)
 bone_name = "foot_l"
 bone_idx = 18
 
@@ -2589,7 +2588,7 @@ scenes = Array[PackedScene]([ExtResource("6_bo8be")])
 copy_transform_node = NodePath(".")
 
 [node name="right_foot" type="BoneAttachment3D" parent="Mesh/reaper/Reaper/Skeleton3D" index="5"]
-transform = Transform3D(-0.999908, 0.0135875, -0.000293263, -0.011904, -0.886026, -0.463482, -0.00655741, -0.463436, 0.886106, -0.116333, 0.116391, 0.42105)
+transform = Transform3D(-0.99982, -0.0154742, -0.0110165, 0.0115822, -0.0369606, -0.999249, 0.0150555, -0.999197, 0.0371333, -0.0882446, 0.0295319, -0.130525)
 bone_name = "foot_l"
 bone_idx = 18
 

--- a/actors/cinematic.gd
+++ b/actors/cinematic.gd
@@ -1,3 +1,5 @@
+ # For cinematic cameras that need to become active. Use make_current() instead of animating current boolean property directly. 
+# Because animation player can potentially overwrite and mess up some of the functionality of this script
 extends Node
 @export var SAVE_KEY: String = "" ## Save if completed for one time cutscenes 
 @export var SKIPPER_GROUP: String = "skipper" ## Skipper node enables skip function
@@ -8,32 +10,39 @@ extends Node
 @export var PLAYER_SPOT: Node3D
 @export var ANIMATION_PLAYER_GROUPS: Array[String]
 @export var ANIMATION_NAMES: Array[String]
+@export var TARGET_CAMERA_GROUP: String = "player_camera"
 var last_player_body : Node = null
 
-@export_group("Seamless transition")
-@export var CINEMATIC_CAMERA_GROUP: String = "cinematic_camera"
-@export var TARGET_CAMERA_GROUP: String = "player_camera"
-
-func _seamless_camera_transition(duration: float = 1.5) -> void: # todo add making it go in reverse player cam to cinematic
-	var cinematic_list = get_tree().get_nodes_in_group(CINEMATIC_CAMERA_GROUP)
-	var target_list = get_tree().get_nodes_in_group(TARGET_CAMERA_GROUP)
-	if cinematic_list.size() == 0 or target_list.size() == 0: return
-	var cinematic_camera = cinematic_list[0]
-	var target_camera = target_list[0]
+func _seamless_camera_transition(duration: float = 1.5, save_completed: bool = false) -> void: # todo add making it go in reverse player cam to cinematic
+	var active_camera: Camera3D = get_viewport().get_camera_3d()
+	var target_camera = get_tree().get_nodes_in_group(TARGET_CAMERA_GROUP)[0]
+	if active_camera == target_camera: return
+	if cinematic_completed(): return
+	
 	var tween = get_tree().create_tween()
 	tween.set_parallel(true)
-	tween.tween_property(cinematic_camera, "global_transform", target_camera.global_transform, duration).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
-	tween.tween_property(cinematic_camera, "fov", target_camera.fov, duration).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+	tween.tween_property(active_camera, "global_transform", target_camera.global_transform, duration).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+	tween.tween_property(active_camera, "fov", target_camera.fov, duration).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+	tween.finished.connect(func(): 
+		target_camera.make_current()
+		if save_completed: save_cinematic_completed()
+		)
 
 func _skip_cinematic() -> void:
 	await get_tree().process_frame # Autoload doesnt start playing until after ready so wait until an animation is playing so seek works
 	if not is_inside_tree(): return
+	
+	save_cinematic_completed()
+	get_tree().get_nodes_in_group(TARGET_CAMERA_GROUP)[0].make_current()
 
 	for skipper in get_tree().get_nodes_in_group(SKIPPER_GROUP):
 		if "_skip" in skipper:
 			skipper._skip(false)
 
-func _save_cinematic_completed() -> void:
+func cinematic_completed() -> bool:
+	return SAVE_KEY != "" and Save.data.has(SAVE_KEY)
+
+func save_cinematic_completed() -> void:
 	if SAVE_KEY == "": return
 	Save.data[SAVE_KEY] = true
 	Save.save_game()

--- a/menus/skip/skip.gd
+++ b/menus/skip/skip.gd
@@ -5,6 +5,8 @@ extends Node
 @export var ANIMATION_PLAYER: AnimationPlayer ## Animation player for the overlay
 @export var ANIMATION_SKIPPING_NAME: String = "SKIPPING" ## Animation name that fills up skip
 @export var ANIMATION_SKIPPED_NAME: String = "SKIPPED" ## Animation name for when skip has been confirmed
+@export var SKIP_CALLBACK_GROUP: String = "skip_callback" ## For nodes that need to do extra function calls when skipped 
+@export var SKIP_CALLBACK_METHOD: String = "on_skip" ## Name of functions to call
 
 func skippable_animation_playing() -> bool: ## Returns wether theres any animation players playing an animation with skippable marker
 	for node in get_tree().get_nodes_in_group(SKIPPABLE_GROUP):
@@ -24,6 +26,10 @@ func _skip(play_fade: bool = true) -> void:
 	
 	for node in get_tree().get_nodes_in_group(DESTROY_GROUP):
 		node.queue_free()
+	
+	for node in get_tree().get_nodes_in_group(SKIP_CALLBACK_GROUP):
+		if node.has_method(SKIP_CALLBACK_METHOD):
+			node.call(SKIP_CALLBACK_METHOD)
 	
 	if play_fade: ANIMATION_PLAYER.play(ANIMATION_SKIPPED_NAME)
 				

--- a/stages/level_1_lust/castle.tscn
+++ b/stages/level_1_lust/castle.tscn
@@ -64,18 +64,6 @@ tracks/2/keys = {
 "update": 0,
 "values": [Vector3(-1.3911, -1.36746, 0)]
 }
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("Cinematic/Camera3D:current")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="Animation" id="Animation_1tft3"]
 resource_name = "introduction"
@@ -83,7 +71,7 @@ length = 25.0
 markers = [{
 "color": Color(1, 1, 1, 1),
 "name": &"skip",
-"time": 22.5
+"time": 21.5333
 }]
 tracks/0/type = "value"
 tracks/0/imported = false
@@ -121,17 +109,19 @@ tracks/2/keys = {
 "update": 0,
 "values": [Vector3(-1.3911, -1.36746, 0), Vector3(-0.649341, -0.782785, 0), Vector3(0.349862, -1.09265, 0)]
 }
-tracks/3/type = "value"
+tracks/3/type = "method"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("Cinematic/Camera3D:current")
-tracks/3/interp = 0
+tracks/3/path = NodePath("Cinematic/Camera3D")
+tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
-"times": PackedFloat32Array(0, 22.5),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [true, false]
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"make_current"
+}]
 }
 tracks/4/type = "method"
 tracks/4/imported = false
@@ -146,22 +136,8 @@ tracks/4/keys = {
 "args": [],
 "method": &"_play_animations_in_other_nodes"
 }, {
-"args": [],
+"args": [1.5, true],
 "method": &"_seamless_camera_transition"
-}]
-}
-tracks/5/type = "method"
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/path = NodePath("Cinematic")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/keys = {
-"times": PackedFloat32Array(21.7333),
-"transitions": PackedFloat32Array(1),
-"values": [{
-"args": [],
-"method": &"_save_cinematic_completed"
 }]
 }
 
@@ -274,8 +250,9 @@ ANIM = NodePath(".")
 ANIMATION_PLAYER_GROUPS = Array[String](["player_anim"])
 ANIMATION_NAMES = Array[String](["INTRODUCTION"])
 
-[node name="Camera3D" type="Camera3D" parent="Cinematic" groups=["cinematic_camera"]]
+[node name="Camera3D" type="Camera3D" parent="Cinematic"]
 transform = Transform3D(0.201938, 0.963628, -0.175049, 0, 0.178731, 0.983898, 0.979398, -0.198686, 0.0360925, -57.055, 978.878, 47.6623)
+current = true
 fov = 50.0
 
 [node name="Door" type="Node" parent="."]

--- a/stages/level_8_portal/level_8.tscn
+++ b/stages/level_8_portal/level_8.tscn
@@ -78,53 +78,55 @@ tracks/1/keys = {
 "update": 0,
 "values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
 }
-tracks/2/type = "value"
+tracks/2/type = "method"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("../Cinematic/Camera3D:position")
-tracks/2/interp = 2
+tracks/2/path = NodePath("../Cinematic/Camera3D")
+tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0.7, 6.36667, 11.2),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector3(-17.2564, 8.33722, 7.99027), Vector3(-0.10612, -1.82124, 12.0556), Vector3(-0.920525, -4.00207, -28.7983)]
+"times": PackedFloat32Array(0.7),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"make_current"
+}]
 }
 tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("../Cinematic/Camera3D:rotation")
+tracks/3/path = NodePath("../Cinematic/Camera3D:position")
 tracks/3/interp = 2
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "times": PackedFloat32Array(0.7, 6.36667, 11.2),
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
-"values": [Vector3(-0.609082, -2.29252, 0), Vector3(-0.0985731, -3.10846, 0), Vector3(0.00178329, -3.11719, 0)]
+"values": [Vector3(-17.2564, 8.33722, 7.99027), Vector3(-0.10612, -1.82124, 12.0556), Vector3(-0.920525, -4.00207, -28.7983)]
 }
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("../Cinematic/Camera3D:fov")
-tracks/4/interp = 1
+tracks/4/path = NodePath("../Cinematic/Camera3D:rotation")
+tracks/4/interp = 2
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "times": PackedFloat32Array(0.7, 6.36667, 11.2),
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
-"values": [91.859, 102.239, 45.015]
+"values": [Vector3(-0.609082, -2.29252, 0), Vector3(-0.0985731, -3.10846, 0), Vector3(0.00178329, -3.11719, 0)]
 }
 tracks/5/type = "value"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("../Cinematic/Camera3D:current")
+tracks/5/path = NodePath("../Cinematic/Camera3D:fov")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
-"times": PackedFloat32Array(0, 0.7),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [false, true]
+"times": PackedFloat32Array(0.7, 6.36667, 11.2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [91.859, 102.239, 45.015]
 }
 tracks/6/type = "method"
 tracks/6/imported = false
@@ -232,18 +234,6 @@ tracks/4/keys = {
 "update": 0,
 "values": [91.859]
 }
-tracks/5/type = "value"
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/path = NodePath("../Cinematic/Camera3D:current")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_ses4i"]
 _data = {
@@ -338,13 +328,13 @@ ANIMATION_PLAYER_GROUPS = Array[String](["player_anim"])
 ANIMATION_NAMES = Array[String](["ESCAPE"])
 
 [node name="spin" parent="Portal/Mesh" index="1"]
-transform = Transform3D(0.587882, 0.808945, 0, -0.808945, 0.587882, 0, 0, 0, 1, 0.000288624, 0.12951, -0.0294213)
+transform = Transform3D(-0.465837, 0.884869, 0, -0.884869, -0.465837, 0, 0, 0, 1, 0.000288624, 0.12951, -0.0294213)
 
 [node name="fire1_002" parent="Portal/Mesh/flames_2" index="0"]
-transform = Transform3D(-0.825641, 0.175444, -3.11332e-16, -0.175444, -0.825641, 5.26395e-15, 7.89595e-16, 5.2137e-15, 0.844076, 15.7583, 0.222717, -15.5292)
+transform = Transform3D(-0.153844, 0.862129, -1.48805e-15, -0.862129, -0.153844, 4.21775e-15, 3.89075e-15, 2.20585e-15, 0.875748, 15.7583, 0.222717, -15.5292)
 
 [node name="fire1_001" parent="Portal/Mesh/flames_1" index="0"]
-transform = Transform3D(-0.825641, 0.175444, -3.11332e-16, -0.175444, -0.825641, 5.26395e-15, 7.89595e-16, 5.2137e-15, 0.844076, 15.7583, 0.222717, -15.7353)
+transform = Transform3D(-0.153844, 0.862129, -1.48805e-15, -0.862129, -0.153844, 4.21775e-15, 3.89075e-15, 2.20585e-15, 0.875748, 15.7583, 0.222717, -15.7353)
 
 [node name="AnimationPlayer" parent="Portal/Mesh" index="4"]
 autoplay = "Spin"


### PR DESCRIPTION
…nematics. It just automatically grabs the active camera and tweens to target camera. In theory this means less work having to specify current in animation playe. But have to worry about not animating current boolean property in cinematic animation players. Forced to use make current. Aswell as requiring skip script to have a lot more functionality. Stashing this change in this branch though in case this general direction ever ends up feeling like the right direction